### PR TITLE
Wire up with flapjack Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 
+## 0.2.0
+
+### Added
+- pytz dependency for timezone use
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Function to get fields from Event
+
+### Fixed
+- Flapjack Event document type wiring.
+
 ## 0.1.0 
 
 ### Added

--- a/flask_eventics/controllers.py
+++ b/flask_eventics/controllers.py
@@ -112,9 +112,8 @@ def generate_ics(event_slug):
     for ics_field, timezoneName in tz_dict.items():
         if ics_field in ics_fields:
             esdate = dateutil.parser.parse(ics_fields[ics_field])
-            naive = esdate.replace(tzinfo=None)
             if timezoneName in ics_fields:
-                date = timezone(ics_fields[timezoneName]).localize(naive)
+                date = esdate.astimezone(timezone(ics_fields[timezoneName]))
             else:
                 date = esdate.astimezone(timezone('UTC'))
             event.add(ics_field, date)


### PR DESCRIPTION
This matches up fields from the Event document type in ES. 
## Dependencies

This requires [this PR to be pulled in](https://github.com/cfpb/cfgov-refresh/pull/681)
### Test
- You must have an Event indexed within an ES index at `localhost:9200`
- Fire up a sheer `sheer serve`
- Go to `localhost:7000/events/<event_slug>/ics`
- A file should be generated with the correct times and dates in accordance with the timezone selected 
  for each date used.

@jimmynotjim @sebworks @anselmbradford @KimberlyMunoz 
